### PR TITLE
Changed base image to NodeCG official image

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,8 +1,10 @@
-FROM node:20-alpine
+FROM ghcr.io/nodecg/nodecg:2
 WORKDIR /opt/nodecg
-RUN apk add --no-cache git make gcc python3 musl-dev g++ trash-cli && npm install --global nodecg-cli && nodecg setup
-COPY . /opt/nodecg/bundles/tpc3stream/
+RUN apk add --no-cache git make gcc python3 musl-dev g++ trash-cli
+USER nodecg
+COPY --chown=nodecg:nodecg . /opt/nodecg/bundles/tpc3stream/
 WORKDIR /opt/nodecg/bundles/tpc3stream/
-RUN npm i && npm run build && apk del git make gcc python3 musl-dev g++ trash-cli
-WORKDIR /opt/nodecg
-CMD ["node", "index.js"]
+RUN npm i && npm run build
+USER root
+RUN apk del git make gcc python3 musl-dev g++ trash-cli
+USER nodecg

--- a/dockerfile
+++ b/dockerfile
@@ -1,10 +1,10 @@
 FROM ghcr.io/nodecg/nodecg:2
 WORKDIR /opt/nodecg
-RUN apk add --no-cache git make gcc python3 musl-dev g++ trash-cli
+RUN apt-get update && apt-get install make gcc python3 musl-dev g++ trash-cli
 USER nodecg
 COPY --chown=nodecg:nodecg . /opt/nodecg/bundles/tpc3stream/
 WORKDIR /opt/nodecg/bundles/tpc3stream/
 RUN npm i && npm run build
 USER root
-RUN apk del git make gcc python3 musl-dev g++ trash-cli
+RUN apt-get remove make gcc python3 musl-dev g++ trash-cli
 USER nodecg

--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,7 @@
 # build phase
-FROM node:18-slim AS build
+FROM ghcr.io/nodecg/nodecg:2 AS build
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+USER root
 RUN apt-get update \
 	&& apt-get install -y trash-cli
 COPY . /tpc3stream


### PR DESCRIPTION
- Changed base image to NodeCG official image (`ghcr.io/nodecg/nodecg:2`)
- Added `build` layer because:
  -  Cannot write in RUN to `/opt/nodecg/bundles` because it is designated as a volume mount.
  - `npm` does not support running users without a home directory.